### PR TITLE
add silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,4 @@ The following flags can be passed to the `prometheus-filesystem-exporter`:
 | `--listen-addr`         | `:8080`     | The address to listen on for http requests
 | `--metrics-directory`   | `/metrics`  | The directory to read metrics from |
 | `--metrics-path`        | `/metrics`  | The http path under which metrics are exposed
+| `--silent`              | `false`     | Silent mode - no logging of metric changes


### PR DESCRIPTION

This patch adds a basic "silent mode" which prevents the prometheus-filesystem-exporter
to log at least two lines for each metric change. Errors are still logged.